### PR TITLE
added global expected in `file_upload`.

### DIFF
--- a/server.py
+++ b/server.py
@@ -21,6 +21,7 @@ def download(number):
 @app.route('/upload', method = 'POST')
 def file_upload():
     uploaded = request.files.get('upload').file.read() #uploaded outputs by user
+    global expected
     expected = expected.strip()
     uploaded = uploaded.strip()
     ans = (uploaded==expected)


### PR DESCRIPTION
we were receiving 
```
expected = expected.strip()
UnboundLocalError: local variable 'expected' referenced before assignment
```
don't know how it got missed. so I just added `expected` as a global variable.