### PR TITLE
WIP: CI with travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ python:
 script:
     - pip3 install pipenv
     - pipenv install --dev
-    - pipenv run pytest
+    - pipenv run pytest -v --disable-pytest-warning

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,14 @@
+dist: xenial
 language: python
 python:
     - "3.6"
     - "3.7-dev"
 
-# command to install dependencies
 install:
     - pip3 install pipenv
     - pipenv install --dev
     
 
-# command to run tests
 script:
     - pipenv run pytest -v --disable-pytest-warning
     - pipenv run black --check ./

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,11 @@ python:
     - "3.7-dev"
 
 # command to install dependencies
-#install: "make"
+install:
+    - pip3 install pipenv
+    - pipenv install --dev
+    
 
 # command to run tests
 script:
-    - pip3 install pipenv
-    - pipenv install --dev
     - pipenv run pytest -v --disable-pytest-warning

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,4 @@ install:
 # command to run tests
 script:
     - pipenv run pytest -v --disable-pytest-warning
+    - pipenv run black --check ./

--- a/Pipfile
+++ b/Pipfile
@@ -13,6 +13,7 @@ peewee = "*"
 [dev-packages]
 requests = "*"
 pytest = "*"
+webtest = "*"
 
 [requires]
 python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c2d78e0bf5fe824233f66af401871c1cab11b264303260a17b277bac99bddaa6"
+            "sha256": "d8d92c5109b925c93e0418570b61914de65c620acd97e44593fae9ce4782e062"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -76,10 +76,10 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:2f2e54cbf6b06b16351e4c40a6adb0860cab6cfb95a0c0fcb58bb789c4b450f5",
-                "sha256:37bbea81dec44d1ff72d58a1b5c1599a9f3436537f33e9e26f276610064c4830"
+                "sha256:0e375a4c177090292988d1c2f997c7c2467d908c1adbed3e08fb511486c85457",
+                "sha256:440815529340fb7fdd6a83ebf4258cc2860fb3770d37b52875e37c6f509a4cd6"
             ],
-            "version": "==0.12"
+            "version": "==0.13"
         },
         "importlib-resources": {
             "hashes": [
@@ -149,10 +149,10 @@
         },
         "zipp": {
             "hashes": [
-                "sha256:46dfd547d9ccbf8bdc26ecea52818046bb28509f12bb6a0de1cd66ab06e9a9be",
-                "sha256:d7ac25f895fb65bff937b381353c14eb1fa23d35f40abd72a5342cd57eb57fd1"
+                "sha256:8c1019c6aad13642199fbe458275ad6a84907634cc9f0989877ccc4a2840139d",
+                "sha256:ca943a7e809cc12257001ccfb99e3563da9af99d52f261725e96dfe0f9275bc3"
             ],
-            "version": "==0.5.0"
+            "version": "==0.5.1"
         }
     },
     "develop": {
@@ -169,6 +169,14 @@
                 "sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"
             ],
             "version": "==19.1.0"
+        },
+        "beautifulsoup4": {
+            "hashes": [
+                "sha256:034740f6cb549b4e932ae1ab975581e6103ac8f942200a0e9759065984391858",
+                "sha256:945065979fb8529dd2f37dbb58f00b661bdbcbebf954f93b32fdf5263ef35348",
+                "sha256:ba6d5c59906a85ac23dadfe5c88deaf3e179ef565f4898671253e50a78680718"
+            ],
+            "version": "==4.7.1"
         },
         "certifi": {
             "hashes": [
@@ -223,11 +231,11 @@
         },
         "requests": {
             "hashes": [
-                "sha256:502a824f31acdacb3a35b6690b5fbf0bc41d63a24a45c4004352b0242707598e",
-                "sha256:7bf2a778576d825600030a110f3c0e3e8edc51dfaafe1c146e39a2027784957b"
+                "sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4",
+                "sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"
             ],
             "index": "pypi",
-            "version": "==2.21.0"
+            "version": "==2.22.0"
         },
         "six": {
             "hashes": [
@@ -236,12 +244,26 @@
             ],
             "version": "==1.12.0"
         },
+        "soupsieve": {
+            "hashes": [
+                "sha256:6898e82ecb03772a0d82bd0d0a10c0d6dcc342f77e0701d0ec4a8271be465ece",
+                "sha256:b20eff5e564529711544066d7dc0f7661df41232ae263619dede5059799cdfca"
+            ],
+            "version": "==1.9.1"
+        },
         "urllib3": {
             "hashes": [
-                "sha256:2393a695cd12afedd0dcb26fe5d50d0cf248e5a66f75dbd89a3d4eb333a61af4",
-                "sha256:a637e5fae88995b256e3409dc4d52c2e2e0ba32c42a6365fee8bbd2238de3cfb"
+                "sha256:a53063d8b9210a7bdec15e7b272776b9d42b2fd6816401a0d43006ad2f9902db",
+                "sha256:d363e3607d8de0c220d31950a8f38b18d5ba7c0830facd71a1c6b1036b7ce06c"
             ],
-            "version": "==1.24.3"
+            "version": "==1.25.2"
+        },
+        "waitress": {
+            "hashes": [
+                "sha256:4e2a6e6fca56d6d3c279f68a2b2cc9b4798d834ea3c3a9db3e2b76b6d66f4526",
+                "sha256:90fe750cd40b282fae877d3c866255d485de18e8a232e93de42ebd9fb750eebb"
+            ],
+            "version": "==1.3.0"
         },
         "wcwidth": {
             "hashes": [
@@ -249,6 +271,21 @@
                 "sha256:f4ebe71925af7b40a864553f761ed559b43544f8f71746c2d756c7fe788ade7c"
             ],
             "version": "==0.1.7"
+        },
+        "webob": {
+            "hashes": [
+                "sha256:05aaab7975e0ee8af2026325d656e5ce14a71f1883c52276181821d6d5bf7086",
+                "sha256:36db8203c67023d68c1b00208a7bf55e3b10de2aa317555740add29c619de12b"
+            ],
+            "version": "==1.8.5"
+        },
+        "webtest": {
+            "hashes": [
+                "sha256:41348efe4323a647a239c31cde84e5e440d726ca4f449859264e538d39037fd0",
+                "sha256:f3a603b8f1dd873b9710cd5a7dd0889cf758d7e1c133b1dae971c04f567e566e"
+            ],
+            "index": "pypi",
+            "version": "==2.0.33"
         }
     }
 }

--- a/server.py
+++ b/server.py
@@ -232,6 +232,7 @@ def rankings():
     ]
     return bottle.template("rankings.html", people=order)
 
+
 def logggedIn():
     if not bottle.request.get_cookie("s_id"):
         return False
@@ -321,6 +322,7 @@ def file_upload(code, number):
 @app.error(404)
 def error404(error):
     return template("error.html", errorcode=error.status_code, errorbody=error.body)
+
 
 if __name__ == "__main__":
     bottle.run(app, host="localhost", port=8080)

--- a/server.py
+++ b/server.py
@@ -322,5 +322,5 @@ def file_upload(code, number):
 def error404(error):
     return template("error.html", errorcode=error.status_code, errorbody=error.body)
 
-
-bottle.run(app, host="localhost", port=8080)
+if __name__ == "__main__":
+    bottle.run(app, host="localhost", port=8080)

--- a/test_server.py
+++ b/test_server.py
@@ -5,24 +5,23 @@ import requests
 
 def test_demo():
     assert 1==1
-"""
-url = 'http://localhost:8080'
 
-def test_question():
-    r = requests.get(url+'/question/1')
-    assert r.status_code == 200
+#url = 'http://localhost:8080'
 
-def test_download():
+#def test_question():
+#    r = requests.get(url+'/question/1')
+#    assert r.status_code == 200
+
+#def test_download():
     #time = datetime.datetime.now()
 
     # type(uploaded) == <class 'bytes'>
     # uploaded outputs by user
-    assert requests.get(url+'/question/1/inputs.txt').status_code == 200
+#    assert requests.get(url+'/question/1/inputs.txt').status_code == 200
 
-def test_file_upload():
-    files= {'upload' : open('files/questions/1/output.txt', 'rb')}
-    global url
-    check_url = url + '/check/1'
+#def test_file_upload():
+#    files= {'upload' : open('files/questions/1/output.txt', 'rb')}
+#    global url
+#    check_url = url + '/check/1'
 
-    assert requests.post(check_url, files = files).status_code == 200
-"""
+#    assert requests.post(check_url, files = files).status_code == 200

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,12 +1,22 @@
-import unittest
 import pytest
-#import server as app
-import requests
+from server import app
+from webtest import TestApp
+#import requests
+
+#url = 'http://localhost:8080'
 
 def test_demo():
     assert 1==1
 
-#url = 'http://localhost:8080'
+@pytest.fixture(scope='module')
+def application():
+    test_app = TestApp(app)
+    return test_app
+
+def test_handlers(application):
+    handlers = ["/dashboard","/home"]
+    for handler in handlers:
+        assert application.get(handler).status == '200 OK'
 
 #def test_question():
 #    r = requests.get(url+'/question/1')

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,35 +1,40 @@
 import pytest
 from server import app
 from webtest import TestApp
-#import requests
 
-#url = 'http://localhost:8080'
+# import requests
+
+# url = 'http://localhost:8080'
+
 
 def test_demo():
-    assert 1==1
+    assert 1 == 1
 
-@pytest.fixture(scope='module')
+
+@pytest.fixture(scope="module")
 def application():
     test_app = TestApp(app)
     return test_app
 
-def test_handlers(application):
-    handlers = ["/dashboard","/home"]
-    for handler in handlers:
-        assert application.get(handler).status == '200 OK'
 
-#def test_question():
+def test_handlers(application):
+    handlers = ["/dashboard", "/home"]
+    for handler in handlers:
+        assert application.get(handler).status == "200 OK"
+
+
+# def test_question():
 #    r = requests.get(url+'/question/1')
 #    assert r.status_code == 200
 
-#def test_download():
-    #time = datetime.datetime.now()
+# def test_download():
+# time = datetime.datetime.now()
 
-    # type(uploaded) == <class 'bytes'>
-    # uploaded outputs by user
+# type(uploaded) == <class 'bytes'>
+# uploaded outputs by user
 #    assert requests.get(url+'/question/1/inputs.txt').status_code == 200
 
-#def test_file_upload():
+# def test_file_upload():
 #    files= {'upload' : open('files/questions/1/output.txt', 'rb')}
 #    global url
 #    check_url = url + '/check/1'


### PR DESCRIPTION
I made a custom CI configuration, not sure if this one is correct. I had a few problems.
* `pytest` had to be run in `pipenv`. Therefore I had to add the installation commands (which I added under `scripts`). I think they should not be added under scripts, I found another implementation on the web using `make`, but could not implement it (made a lot of commits during testing so had to fork again, 'coz I got it messed up).
* The present format in which tests are written, we have to run `server.py` first and then `pytest`, I think this can be done better, I found an implementation with https://pypi.org/project/WebTest/ which looks better to me. So I commented the tests and make a `demo` test case with `assert 1==1`
* `travis-ci` would have to be added to PyJaipur/PyJudge by someone with admin access.

Roadmap:
- [x] configure `travis-ci` properly
- [x] formatting check with black in CI
- [x] test the `bottle` framework correctly (*using `WebTest` maybe*)
- [ ] add more tests

This can be done in separate PRs too, because tests might mess things up :)

fixes #125 